### PR TITLE
Fix Styles If Already Assigned

### DIFF
--- a/src/api/html5media.js
+++ b/src/api/html5media.js
@@ -313,10 +313,12 @@
         replacement.style.cssText = element.style.cssText;
         replacement.className = element.className;
         replacement.title = element.title;
-        replacement.style.display = "block";
+        if (!element.style.display) {
+            replacement.style.display = "block";
+        }
         replacement.style.width = getDimension(element, "width", "300px");
         if (tagName == "audio") {
-            replacement.style.height = "26px";
+            replacement.style.height = getDimension(element, "height", "26px");
             replacement.className = (replacement.className ? replacement.className+" " : "")+html5media.audioFallbackClass;
         } else {
             replacement.style.height = getDimension(element, "height", "200px");


### PR DESCRIPTION
The fallback element will always be set as a block element as it currently is. I needed the ability to set it as hidden on load, so I set the script to only set to block if it doesn't exist. The audio height also was set to always be 26px high. People may want to set this also, so I put through the getDimension function.